### PR TITLE
Add playbook and module to list cluster events

### DIFF
--- a/clusters.yml
+++ b/clusters.yml
@@ -39,4 +39,3 @@
       debug:
         var: delete_cluster
       when: delete_cluster is defined
-

--- a/events.yml
+++ b/events.yml
@@ -6,9 +6,10 @@
       events:
         action: list
         cluster_id: "{{ my_cluster_id }}"
-        limit: "{{ cluster_events_limit | default(10) }}"
+        limit: "{{ cluster_events_limit | default(omit) }}"
         order: "{{ cluster_events_order | default('ascending') }}"
         offset: "{{ cluster_events_offset | default(0) }}"
+        severities: "{{ cluster_events_severities | default(omit) }}"
       register: list_cluster_events
       when: my_cluster_id is defined
 

--- a/events.yml
+++ b/events.yml
@@ -8,6 +8,7 @@
         cluster_id: "{{ my_cluster_id }}"
         limit: "{{ cluster_events_limit | default(10) }}"
         order: "{{ cluster_events_order | default('ascending') }}"
+        offset: "{{ cluster_events_offset | default(0) }}"
       register: list_cluster_events
 
     - name: Print cluster events list

--- a/events.yml
+++ b/events.yml
@@ -1,0 +1,14 @@
+- name: Test cluster events
+  hosts: localhost
+  tasks:
+
+    - name: Get list of events for a cluster
+      events:
+        action: list
+        cluster_id: "{{ my_cluster_id }}"
+        limit: "{{ cluster_events_limit | default(10) }}"
+      register: list_cluster_events
+
+    - name: Print cluster events list
+      debug:
+        var: list_cluster_events

--- a/events.yml
+++ b/events.yml
@@ -7,6 +7,7 @@
         action: list
         cluster_id: "{{ my_cluster_id }}"
         limit: "{{ cluster_events_limit | default(10) }}"
+        order: "{{ cluster_events_order | default('ascending') }}"
       register: list_cluster_events
 
     - name: Print cluster events list

--- a/events.yml
+++ b/events.yml
@@ -10,7 +10,9 @@
         order: "{{ cluster_events_order | default('ascending') }}"
         offset: "{{ cluster_events_offset | default(0) }}"
       register: list_cluster_events
+      when: my_cluster_id is defined
 
     - name: Print cluster events list
       debug:
         var: list_cluster_events
+      when: list_cluster_events is defined

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -117,6 +117,9 @@ def run_module():
 
     # List cluster events
     if module.params.get('action') == "list":
+        if not module.params.get('cluster_id'):
+            module.fail_json(msg="cluster_id is required for list cluster events action")
+        
         list_params = {}
         for k in QUERY_PARAMS_LIST:
             val = module.params.get(k)

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -94,7 +94,7 @@ API_VERSION = "v2"
 API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
 # add additional query parameters to the query_params_list
-QUERY_PARAMS_LIST = ["limit", "order", "offset"]
+QUERY_PARAMS_LIST = ["cluster_id","limit", "order", "offset"]
 
 def run_module():
     module_args = dict(
@@ -123,7 +123,7 @@ def run_module():
             if val:
                 list_params = list_params | { k: val }
 
-        response = requests.get(f"{API_URL}/events?cluster_id={module.params.get('cluster_id')}", params=list_params, headers=headers)
+        response = requests.get(f"{API_URL}/events", params=list_params, headers=headers)
 
         if not response.ok:
             result = dict(changed=True, response=response.text)

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -43,8 +43,6 @@ options:
         description: Retrieve events mapped to the severity value.
         required: false
         type: list
-        items:
-            type: string
         choices: [ info, warning, error, critical ]
 
 author:
@@ -60,7 +58,7 @@ EXAMPLES = r"""
     limit: 50
     order: descending
     offset: 10
-    severities: critical, info
+    severities: [ "critical", "info" ]
 """
 
 RETURN = r"""
@@ -130,7 +128,8 @@ def run_module():
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
     # Fail if requests is not installed
-    module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
+    if not HAS_REQUESTS:
+        module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
 
     # Set headers
     headers = {
@@ -141,8 +140,7 @@ def run_module():
     # List cluster events
     if module.params.get('action') == "list":
         if not module.params.get('cluster_id'):
-            module.fail_json(msg="cluster_id is required for list cluster events action")
-        
+            module.fail_json(msg="cluster_id is required for list cluster events action") 
         list_params = {}
         for k in QUERY_PARAMS_LIST:
             val = module.params.get(k)

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -43,6 +43,7 @@ options:
         description: Retrieve events mapped to the severity value.
         required: false
         type: list
+        elements: str
         choices: [ info, warning, error, critical ]
 
 author:
@@ -151,7 +152,7 @@ def run_module():
                     list_params = list_params | {k: ",".join(val)}
                 else:
                     list_params = list_params | {k: val}
-      
+
         response = requests.get(f"{API_URL}/events", params=list_params, headers=headers)
 
         if not response.ok:

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -21,14 +21,14 @@ description: Interact with cluster events through the AssistedInstall API
 
 options:
     action:
-        description: The action to perform
+        description: The action to perform.
         required: false
         default: "list"
     cluster_id:
-        description: The cluster ID to perform the action on
+        description: The cluster ID to perform the action on.
         required: false
     limit:
-        description: The maximum number of records/events to retrieve
+        description: The maximum number of records/events to retrieve.
         default: 10
         required: false
         type: integer
@@ -37,6 +37,10 @@ options:
         default: ascending
         required: false
         type: string
+    offset:
+        description: Number of events to skip before events retrieval.
+        required: false
+        type: integer
 
 author:
     - Akash Gopalakrishnan (@agopalak)
@@ -49,6 +53,8 @@ EXAMPLES = r"""
     action: list
     cluster_id: "deadmeat-dead-meat-dead-meatdeadmeat"
     limit: 50
+    order: descending
+    offset: 10
 """
 
 RETURN = r"""
@@ -88,7 +94,7 @@ API_VERSION = "v2"
 API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
 # add additional query parameters to the query_params_list
-QUERY_PARAMS_LIST = ["limit", "order"]
+QUERY_PARAMS_LIST = ["limit", "order", "offset"]
 
 def run_module():
     module_args = dict(
@@ -96,6 +102,7 @@ def run_module():
         cluster_id=dict(type="str", required=False),
         # any API query parameters may have to be added here
         limit=dict(type="int", required=False, default=10),
+        offset=dict(type="int", required=False, default=0),        
         order=dict(type="str",required=False, default="ascending"),
     )
 

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -20,28 +20,29 @@ options:
         description: The action to perform.
         required: false
         default: "list"
+        type: str
     cluster_id:
         description: The cluster ID to perform the action on.
-        type: string
+        type: str
     limit:
         description: The maximum number of records/events to retrieve.
         required: false
-        type: integer
+        type: int
     order:
         description: Retrieval order for cluster events based on time of events.
         default: ascending
         required: false
-        type: string
+        type: str
         choices: [ ascending, descending ]
     offset:
         description: Number of events to skip before events retrieval.
         required: false
-        type: integer
+        type: int
         default: 0
     severities:
         description: Retrieve events mapped to the severity value.
         required: false
-        type: array
+        type: list
         items:
             type: string
         choices: [ info, warning, error, critical ]
@@ -53,7 +54,7 @@ author:
 EXAMPLES = r"""
 # Use argument
 - name: List cluster events
-  events
+  events:
     action: list
     cluster_id: "deadmeat-dead-meat-dead-meatdeadmeat"
     limit: 50
@@ -111,17 +112,18 @@ API_VERSION = "v2"
 API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
 # add additional query parameters to the query_params_list
-QUERY_PARAMS_LIST = ["cluster_id","limit", "order", "offset", "severities"]
+QUERY_PARAMS_LIST = ["cluster_id", "limit", "order", "offset", "severities"]
+
 
 def run_module():
     module_args = dict(
         action=dict(type="str", required=False, default="list"),
         cluster_id=dict(type="str", required=False),
         # any API query parameters may have to be added here
-        limit=dict(type="int", required=False, default=10),
-        offset=dict(type="int", required=False, default=0),        
-        order=dict(type="str",required=False, default="ascending", choices=["ascending", "descending"]),
-        severities=dict(type="list",required=False, choices=["info", "warning", "error", "critical"]),
+        limit=dict(type="int", required=False),
+        offset=dict(type="int", required=False, default=0),
+        order=dict(type="str", required=False, default="ascending", choices=["ascending", "descending"]),
+        severities=dict(type="list", required=False, choices=["info", "warning", "error", "critical"]),
     )
 
     token = os.environ.get('AI_API_TOKEN')
@@ -156,7 +158,7 @@ def run_module():
             result = dict(changed=True, response=response.text)
             module.fail_json(msg="Error listing cluster events", **result)
 
-        result = dict(changed=False,cluster_events=response.json())
+        result = dict(changed=False, cluster_events=response.json())
 
     module.exit_json(**result)
 

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -59,9 +59,7 @@ EXAMPLES = r"""
     limit: 50
     order: descending
     offset: 10
-    severities:
-        - "critical"
-        - "info"
+    severities: [ "critical", "info"]
 """
 
 RETURN = r"""
@@ -124,7 +122,7 @@ def run_module():
         limit=dict(type="int", required=False),
         offset=dict(type="int", required=False, default=0),
         order=dict(type="str", required=False, default="ascending", choices=["ascending", "descending"]),
-        severities=dict(type="list", required=False, choices=["info", "warning", "error", "critical"]),
+        severities=dict(type="list", elements="str", required=False, choices=["info", "warning", "error", "critical"]),
     )
 
     token = os.environ.get('AI_API_TOKEN')

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -58,7 +58,9 @@ EXAMPLES = r"""
     limit: 50
     order: descending
     offset: 10
-    severities: [ "critical", "info" ]
+    severities:
+        - "critical"
+        - "info"
 """
 
 RETURN = r"""
@@ -140,7 +142,7 @@ def run_module():
     # List cluster events
     if module.params.get('action') == "list":
         if not module.params.get('cluster_id'):
-            module.fail_json(msg="cluster_id is required for list cluster events action") 
+            module.fail_json(msg="cluster_id is required for list cluster events action")
         list_params = {}
         for k in QUERY_PARAMS_LIST:
             val = module.params.get(k)
@@ -149,7 +151,7 @@ def run_module():
                     list_params = list_params | {k: ",".join(val)}
                 else:
                     list_params = list_params | {k: val}
-            
+      
         response = requests.get(f"{API_URL}/events", params=list_params, headers=headers)
 
         if not response.ok:

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -21,9 +21,9 @@ description: Interact with cluster events through the AssistedInstall API
 
 options:
     action:
-      description: The action to perform
-      required: false
-      default: "list"
+        description: The action to perform
+        required: false
+        default: "list"
     cluster_id:
         description: The cluster ID to perform the action on
         required: false
@@ -32,6 +32,11 @@ options:
         default: 10
         required: false
         type: integer
+    order:
+        description: Retrieval order for cluster events based on time of events.
+        default: ascending
+        required: false
+        type: string
 
 author:
     - Akash Gopalakrishnan (@agopalak)
@@ -83,7 +88,7 @@ API_VERSION = "v2"
 API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
 # add additional query parameters to the query_params_list
-QUERY_PARAMS_LIST = ["limit"]
+QUERY_PARAMS_LIST = ["limit", "order"]
 
 def run_module():
     module_args = dict(
@@ -91,6 +96,7 @@ def run_module():
         cluster_id=dict(type="str", required=False),
         # any API query parameters may have to be added here
         limit=dict(type="int", required=False, default=10),
+        order=dict(type="str",required=False, default="ascending"),
     )
 
     token = os.environ.get('AI_API_TOKEN')

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+import os
+import requests
+
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: events
+
+short_description: Handle AssistedInstall cluster events
+
+version_added: "1.0.0"
+
+description: Interact with cluster events through the AssistedInstall API
+
+options:
+    action:
+      description: The action to perform
+      required: false
+      default: "list"
+    cluster_id:
+        description: The cluster ID to perform the action on
+        required: false
+    limit:
+        description: The maximum number of records/events to retrieve
+        default: 10
+        required: false
+        type: integer
+
+author:
+    - Akash Gopalakrishnan (@agopalak)
+"""
+
+EXAMPLES = r"""
+# Use argument
+- name: List cluster events
+  events
+    action: list
+    cluster_id: "deadmeat-dead-meat-dead-meatdeadmeat"
+    limit: 50
+"""
+
+RETURN = r"""
+cluster_events:
+    description: A list of cluster events
+    type: dict
+    returned: always
+    sample: [
+            {
+                "cluster_id": "46f3094d-8967-4f1d-ad09-d5fdfda3830a",
+                "event_time": "2024-11-08T20:15:44.447Z",
+                "message": "Successfully registered cluster",
+                "name": "cluster_registration_succeeded",
+                "severity": "info"
+            },
+            {
+                "cluster_id": "46f3094d-8967-4f1d-ad09-d5fdfda3830a",
+                "event_time": "2024-11-08T20:15:44.652Z",
+                "infra_env_id": "33f1638b-0419-4bc9-ac20-4baddcf14a30",
+                "message": "Updated image information (Image type is \"minimal-iso\", SSH public key is not set)",
+                "name": "image_info_updated",
+                "severity": "info"
+            },
+            {
+                "cluster_id": "46f3094d-8967-4f1d-ad09-d5fdfda3830a",
+                "event_time": "2024-11-08T20:15:52.436Z",
+                "message": "Updated status of the cluster to pending-for-input",
+                "name": "cluster_status_updated",
+                "severity": "info"
+            }
+        ]
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+API_VERSION = "v2"
+API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
+
+# add additional query parameters to the query_params_list
+QUERY_PARAMS_LIST = ["limit"]
+
+def run_module():
+    module_args = dict(
+        action=dict(type="str", required=False, default="list"),
+        cluster_id=dict(type="str", required=False),
+        # any API query parameters may have to be added here
+        limit=dict(type="int", required=False, default=10),
+    )
+
+    token = os.environ.get('AI_API_TOKEN')
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    # Set headers
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {token}'
+    }
+
+    # List cluster events
+    if module.params.get('action') == "list":
+        list_params = {}
+        for k in QUERY_PARAMS_LIST:
+            val = module.params.get(k)
+            if val:
+                list_params = list_params | { k: val }
+
+        response = requests.get(f"{API_URL}/events?cluster_id={module.params.get('cluster_id')}", params=list_params, headers=headers)
+
+        if not response.ok:
+            result = dict(changed=True, response=response.text)
+            module.fail_json(msg="Error listing cluster events", **result)
+
+        result = dict(changed=False,cluster_events=response.json())
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/register_cluster.py
+++ b/plugins/modules/register_cluster.py
@@ -60,6 +60,7 @@ else:
 API_VERSION = "v2"
 API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
+
 def run_module():
     module_args = dict(
         data=dict(type="dict", required=True),
@@ -70,7 +71,7 @@ def run_module():
 
     # Fail if requests is not installed
     if not HAS_REQUESTS:
-       module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR) 
+        module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
 
     # Set headers
     headers = {

--- a/plugins/modules/register_cluster.py
+++ b/plugins/modules/register_cluster.py
@@ -29,7 +29,7 @@ author:
 EXAMPLES = r"""
 # Use argument
 - name: Register cluster
-  register_cluster
+  register_cluster:
     data: {
         'name': 'testcluster',
         'openshift_version': '4.16',

--- a/plugins/modules/register_cluster.py
+++ b/plugins/modules/register_cluster.py
@@ -19,8 +19,9 @@ options:
     data:
         description: JSON data for AssistedInstaller
         type: dict
-        requried: true
-    NOTE: AI_API_TOKEN and AI_PULL_SECRET env variables must be set
+        required: true
+
+notes: AI_API_TOKEN and AI_PULL_SECRET env variables must be set
 
 author:
     - Daniel Kostecki (@dkosteck)

--- a/plugins/modules/register_cluster.py
+++ b/plugins/modules/register_cluster.py
@@ -20,8 +20,7 @@ options:
         description: JSON data for AssistedInstaller
         type: dict
         required: true
-
-notes: AI_API_TOKEN and AI_PULL_SECRET env variables must be set
+    ## Note: AI_API_TOKEN and AI_PULL_SECRET env variables must be set
 
 author:
     - Daniel Kostecki (@dkosteck)

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -3,3 +3,4 @@ plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/register_cluster.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -2,3 +2,4 @@ plugins/modules/architectures.py validate-modules:missing-gplv3-license # ignore
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -3,3 +3,4 @@ plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/register_cluster.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -2,3 +2,4 @@ plugins/modules/architectures.py validate-modules:missing-gplv3-license # ignore
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -3,3 +3,4 @@ plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/register_cluster.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -2,3 +2,4 @@ plugins/modules/architectures.py validate-modules:missing-gplv3-license # ignore
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/features.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3


### PR DESCRIPTION
Created a playbook and module to list cluster events based on given cluster ID. 
An additional input is the number of events to list which can be modified using the _cluster_events_limit_ variable.

Closes #15 

Additionally, the input to determine the order in which events are listed has also been added which can be modified using the _cluster_events_order_ variable and the default option is in ascending order.

Closes #17 

The input to specify how many events can be skipped before listing them has also been added which can be modified using the _cluster_events_offset_ variable and the default option is 0.

Closes #19 

Limits is handled in here as well, Fix: #18 

The input to specify the severities of events to be listed has also been added which can be modified using the _cluster_events_severities_ variable.

Closes #16 