### PR TITLE
uses the apitoken.GetToken() method

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 library = plugins/modules
+module_utils = plugins/module_utils

--- a/plugins/modules/operators.py
+++ b/plugins/modules/operators.py
@@ -33,11 +33,15 @@ operators:
     sample: ["lso", "odf", "cnv", "lvm", "mce"]
 """
 
-import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib
+
+try:
+    from ansible_collections.openshift_lab.assisted_installer.plugins.module_utils import apitoken
+except ImportError:
+    from ansible.module_utils import apitoken
 
 try:
     import requests
@@ -54,7 +58,7 @@ API_URL = f"https://api.openshift.com/api/assisted-install/{API_VERSION}"
 
 def run_module():
     module_args = dict()
-    token = os.environ.get('AI_API_TOKEN')
+    token = apitoken.GetToken()
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
     # Fail if requests is not installed


### PR DESCRIPTION
Fixes: #33

This PR uses the GetToken() method from plugins/module_utils/apitoken.py to retrieve the token.

To test the PR, run either or both of the below commands 
``` AI_OFFLINE_TOKEN=<offline token blob obtained from https://console.redhat.com/openshift/token> ansible-playbook operators.yml```

```AI_API_TOKEN=<obtained by executing `ocm token` if ocm binary is installed> ansible-playbook operators.yml```