### PR TITLE
Add unit tests to PRs

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -40,3 +40,33 @@ jobs:
       - name: Run sanity tests
         run: ansible-test sanity -v --docker --color --coverage
         working-directory: ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
+
+  units:
+    name: Unit tests ${{ matrix.ansible }}
+    strategy:
+      matrix:
+        ansible:
+          - stable-2.17
+          - devel
+    runs-on: ubuntu-24.04
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install ansible-base (${{ matrix.ansible }})
+        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible }}.tar.gz --disable-pip-version-check
+
+      - name: Print ansible-test version
+        run: ansible-test --version
+
+      - name: Run unit tests
+        run: ansible-test units --verbose --docker --color --coverage
+        working-directory: ./ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Allow unit tests to be executed when available in a PR.

This change will help to changes like #77 to execute its unit tests  in the same PR.