### PR TITLE
Use apitoken module util for authentication

### DIFF
--- a/plugins/modules/clusters.py
+++ b/plugins/modules/clusters.py
@@ -68,6 +68,12 @@ clusters:
 
 import os
 import traceback
+
+try:
+    from ansible_collections.openshift_lab.assisted_installer.plugins.module_utils import apitoken
+except ImportError:
+    from ansible.module_utils import apitoken
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib
 
@@ -99,7 +105,7 @@ def run_module():
         name=dict(type="str", required=False),
         openshift_version=dict(type="str", required=False),
     )
-    token = os.environ.get("AI_API_TOKEN")
+    token = apitoken.GetToken()
     module = AnsibleModule(
         argument_spec=module_args,
         required_if=[


### PR DESCRIPTION
support_levels and operators is using apitoken module to check the environment variables.

I want as well in future to add the possibility to read a file, it will help for the ansible-test (integration tests)

Solves issue: https://github.com/vjayaramrh/assistedinstaller/issues/80

Closes #80 
Closes #58 