### PR TITLE
renames module from operators to supported_operators

### DIFF
--- a/plugins/modules/supported_operators.py
+++ b/plugins/modules/supported_operators.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 ---
-module: operators
+module: supported_operators
 
 short_description: Information regarding supported operators
 
@@ -17,16 +17,17 @@ description: Assisted Service API to retrieve supported operators
 
 author:
     - Tony García (@tonyskapunk)
+    - Vishwanath Jayaraman (@vjayaramrh)
 """
 
 EXAMPLES = r"""
 # Use argument
 - name: List supported operators
-  operators:
+  supported_operators:
 """
 
 RETURN = r"""
-operators:
+supported_operators:
     description: List of supported operators
     type: list
     returned: always
@@ -80,10 +81,10 @@ def run_module():
         except requests.JSONDecodeError:
             res = response.text
 
-        result = dict(changed=False, response=res, operators=[])
+        result = dict(changed=False, response=res, supported_operators=[])
         module.fail_json(msg="Error listing supported operators", **result)
 
-    result = dict(changed=False, operators=response.json())
+    result = dict(changed=False, supported_operators=response.json())
 
     module.exit_json(**result)
 

--- a/supported_operators.yml
+++ b/supported_operators.yml
@@ -2,9 +2,9 @@
   hosts: localhost
   tasks:
     - name: List supported operators
-      operators:
-      register: operators
+      supported_operators:
+      register: supported_operators
 
     - name: Print listed supported operators
       ansible.builtin.debug:
-        var: operators
+        var: supported_operators

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,5 +1,5 @@
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
-plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/supported_operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,5 +1,5 @@
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
-plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/supported_operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,5 +1,5 @@
 plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
-plugins/modules/operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/supported_operators.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3


### PR DESCRIPTION
To be consistent with using resource name appearing in the REST API path for naming the modules, this PR modifies the file name and ansible module name to use `support_operators` instead of `operators`
closes: #83