### PR TITLE
updated events module to use apitoken.GetToken()

### DIFF
--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -94,6 +94,11 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib
 
 try:
+    from ansible_collections.openshift_lab.assisted_installer.plugins.module_utils import apitoken
+except ImportError:
+    from ansible.module_utils import apitoken
+
+try:
     import requests
 except ImportError:
     HAS_REQUESTS = False
@@ -119,7 +124,7 @@ def run_module():
         severities=dict(type="list", elements="str", required=False, choices=["info", "warning", "error", "critical"]),
     )
 
-    token = os.environ.get('AI_API_TOKEN')
+    token = apitoken.GetToken()
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
 
     # Fail if requests is not installed

--- a/plugins/modules/events.py
+++ b/plugins/modules/events.py
@@ -88,7 +88,6 @@ cluster_events:
         ]
 """
 
-import os
 import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib


### PR DESCRIPTION
## Summary by Sourcery

Update the events Ansible module to use the shared apitoken utility for API token retrieval and support its import from both the collection and core module_utils

Enhancements:
- Refactor token retrieval to call apitoken.GetToken() instead of reading the AI_API_TOKEN environment variable
- Add import fallback to load apitoken from the Ansible collection or core module_utils