### PR TITLE
Update ansible version to test

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         ansible:
-          - stable-2.17
+          - stable-2.18
           - devel
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Use the current stable version which is 2.18

## Summary by Sourcery

CI:
- Bump Ansible test-module workflow matrix from stable-2.17 to stable-2.18