### PR TITLE
Add release_sources Ansible module for v2ListReleaseSources API

### DIFF
--- a/plugins/modules/release_sources.py
+++ b/plugins/modules/release_sources.py
@@ -1,0 +1,101 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: release_sources
+
+short_description: Query release source configurations
+
+version_added: "1.0.0"
+
+description: Retrieves the list of release source configurations from the Assisted Service API.
+
+options: {}
+
+author:
+    - Chris Wheeler (@clwheel)
+"""
+
+EXAMPLES = r"""
+# List all release source configurations
+- name: List release sources
+  release_sources:
+  register: sources_result
+
+- name: Display release sources
+  debug:
+    var: sources_result.release_sources
+"""
+
+RETURN = r"""
+release_sources:
+    description: A list of release source configurations
+    type: list
+    returned: always
+    sample: [
+        {
+            "op_shift_version": "4.19.0",
+            "url": "https://example.com/release-images/4.19.0",
+            "version": "4.19.0"
+        }
+    ]
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import missing_required_lib
+
+try:
+    from ansible_collections.openshift_lab.assisted_installer.plugins.module_utils import apitoken, apiurl
+except ImportError:
+    from ansible.module_utils import apitoken, apiurl
+
+try:
+    import requests
+except ImportError:
+    HAS_REQUESTS = False
+    REQUESTS_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_REQUESTS = True
+    REQUESTS_IMPORT_ERROR = None
+
+
+def run_module():
+    module_args = dict()
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    # Fail if requests is not installed
+    if not HAS_REQUESTS:
+        module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
+
+    # Set headers
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {apitoken.GetToken()}'
+    }
+
+    response = requests.get(
+        apiurl.GetURL("/release-sources"),
+        headers=headers,
+    )
+
+    if not response.ok:
+        result = dict(changed=False, response=response.text)
+        module.fail_json(msg="Error querying release sources", **result)
+
+    module.exit_json(release_sources=response.json())
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main() 

--- a/plugins/modules/release_sources.py
+++ b/plugins/modules/release_sources.py
@@ -98,4 +98,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/release_sources.yml
+++ b/release_sources.yml
@@ -1,0 +1,16 @@
+---
+- name: Test release_sources module
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: List all release source configurations
+      release_sources:
+      register: sources_result
+
+    - name: Display release sources
+      debug:
+        var: sources_result.release_sources
+
+    - name: Show count of release sources
+      debug:
+        msg: "Found {{ sources_result.release_sources | length }} release source(s)" 

--- a/release_sources.yml
+++ b/release_sources.yml
@@ -13,4 +13,4 @@
 
     - name: Show count of release sources
       debug:
-        msg: "Found {{ sources_result.release_sources | length }} release source(s)" 
+        msg: "Found {{ sources_result.release_sources | length }} release source(s)"

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/release_sources.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/release_sources.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/release_sources.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,7 @@
+plugins/modules/clusters.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/supported_operators.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/release_sources.py validate-modules:missing-gplv3-license # ignore gplv3


### PR DESCRIPTION
Implements GET method for the v2ListReleaseSources REST API endpoint.

- Add plugins/modules/release_sources.py module
- Add release_sources.yml test playbook
- Update sanity test ignore files for GPL license validation
- Module follows existing collection patterns and conventions
- Returns list of release source configurations

Assisted-By: Cursor

## Summary by Sourcery

Implement a new release_sources Ansible module for the Assisted Service v2ListReleaseSources endpoint, accompanied by a test playbook and updated sanity ignore configurations.

New Features:
- Add release_sources Ansible module to query the v2ListReleaseSources API and return release source configurations

Tests:
- Add release_sources.yml playbook to validate the new module
- Update sanity ignore files to bypass GPL license checks for new modules