### PR TITLE
Generate component versions module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,46 @@
 - Offline token from  https://console.redhat.com/openshift/token
 - ocm-cli client from https://github.com/openshift-online/ocm-cli/releases or https://console.redhat.com/openshift/downloads#tool-ocm-api-token
 
+## Modules
+
+This collection provides the following modules for interacting with the OpenShift Assisted Installer API:
+
+### component_versions
+Query supported OpenShift component versions from the Assisted Installer API.
+
+**Options:**
+- `openshift_version` (optional): Filter by specific OpenShift version
+- `cpu_architecture` (optional): Filter by CPU architecture (x86_64, aarch64, arm64, ppc64le, s390x, multi)
+
+**Example:**
+```yaml
+- name: List all component versions
+  component_versions:
+  register: all_versions
+
+- name: List component versions for OpenShift 4.18
+  component_versions:
+    openshift_version: "4.18"
+  register: openshift_418_versions
+```
+
+### clusters
+Handle AssistedInstall clusters - create, list, and delete clusters.
+
+### events
+Query events from the Assisted Installer API.
+
+### infra_envs
+Manage infrastructure environments.
+
+### openshift_versions
+Query supported OpenShift versions.
+
+### support_levels
+Query OpenShift support levels for architectures and features.
+
+### supported_operators
+List supported operators.
+
 ## References
 - Swagger UI -> https://api.openshift.com/?urls.primaryName=assisted-service%20service (next select the `assisted-service service` from the top right drop down menu)

--- a/component_versions.yml
+++ b/component_versions.yml
@@ -1,0 +1,38 @@
+- name: Test component_versions
+  hosts: localhost
+  tasks:
+    - name: List all component versions
+      component_versions:
+      register: all_component_versions_result
+
+    - name: Print all component versions
+      ansible.builtin.debug:
+        var: all_component_versions_result
+
+    - name: List component versions for OpenShift 4.18
+      component_versions:
+        openshift_version: "4.18"
+      register: openshift_418_component_versions_result
+
+    - name: Print OpenShift 4.18 component versions
+      ansible.builtin.debug:
+        var: openshift_418_component_versions_result
+
+    - name: List component versions for x86_64 architecture
+      component_versions:
+        cpu_architecture: x86_64
+      register: x86_64_component_versions_result
+
+    - name: Print x86_64 component versions
+      ansible.builtin.debug:
+        var: x86_64_component_versions_result
+
+    - name: List component versions for OpenShift 4.18 on x86_64
+      component_versions:
+        openshift_version: "4.18"
+        cpu_architecture: x86_64
+      register: filtered_component_versions_result
+
+    - name: Print filtered component versions
+      ansible.builtin.debug:
+        var: filtered_component_versions_result

--- a/plugins/modules/component_versions.py
+++ b/plugins/modules/component_versions.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# assisted-by: Claude 3.5 Sonnet (Cursor)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: component_versions
+
+short_description: List OpenShift component versions
+
+version_added: "1.0.0"
+
+description: Retrieves the list of supported OpenShift component versions from the Assisted Installer API.
+
+options:
+  openshift_version:
+    description: Filter by specific OpenShift version
+    required: false
+    type: str
+
+  cpu_architecture:
+    description: Filter by CPU architecture
+    required: false
+    choices: [x86_64, aarch64, arm64, ppc64le, s390x, multi]
+    type: str
+
+author:
+    - Daniel Kostecki (@dkosteck)
+"""
+
+EXAMPLES = r"""
+# List all component versions
+- name: List all component versions
+  component_versions:
+  register: all_component_versions
+
+# List component versions for specific OpenShift version
+- name: List component versions for OpenShift 4.18
+  component_versions:
+    openshift_version: "4.18"
+  register: openshift_418_component_versions
+
+# List component versions for specific architecture
+- name: List component versions for x86_64 architecture
+  component_versions:
+    cpu_architecture: x86_64
+  register: x86_64_component_versions
+
+# List component versions for specific OpenShift version and architecture
+- name: List component versions for OpenShift 4.18 on x86_64
+  component_versions:
+    openshift_version: "4.18"
+    cpu_architecture: x86_64
+  register: filtered_component_versions
+"""
+
+RETURN = r"""
+component_versions:
+  description: A list of supported OpenShift component versions
+  type: dict
+  returned: always
+  sample: {
+    "4.18.1": {
+      "components": {
+        "cluster-version-operator": "4.18.1",
+        "machine-config-operator": "4.18.1",
+        "cluster-network-operator": "4.18.1",
+        "cluster-storage-operator": "4.18.1"
+      },
+      "openshift_version": "4.18.1",
+      "cpu_architecture": "x86_64",
+      "release_image": "quay.io/openshift-release-dev/ocp-release:4.18.1-x86_64"
+    }
+  }
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import missing_required_lib
+
+import traceback
+
+try:
+    from ansible_collections.openshift_lab.assisted_installer.plugins.module_utils import apitoken, apiurl
+except ImportError:
+    from ansible.module_utils import apitoken, apiurl
+
+try:
+    import requests
+except ImportError:
+    HAS_REQUESTS = False
+    REQUESTS_IMPORT_ERROR = traceback.format_exc()
+else:
+    HAS_REQUESTS = True
+    REQUESTS_IMPORT_ERROR = None
+
+QUERY_PARAMS_LIST = [
+    "openshift_version",
+    "cpu_architecture",
+]
+
+
+def run_module():
+    module_args = dict(
+        openshift_version=dict(type="str", required=False),
+        cpu_architecture=dict(type="str", required=False, choices=["x86_64", "aarch64", "arm64", "ppc64le", "s390x", "multi"])
+    )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    # Fail if requests is not installed
+    if not HAS_REQUESTS:
+        module.fail_json(msg=missing_required_lib('requests'), exception=REQUESTS_IMPORT_ERROR)
+
+    # Set headers
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {apitoken.GetToken()}'
+    }
+
+    query_params = {}
+
+    for k in QUERY_PARAMS_LIST:
+        val = module.params.get(k)
+        if val:
+            query_params = query_params | {k: val}
+
+    response = requests.get(
+        apiurl.GetURL("/component-versions"),
+        params=query_params,
+        headers=headers,
+    )
+
+    if not response.ok:
+        try:
+            res = response.json()
+        except requests.JSONDecodeError:
+            res = response.text
+
+        result = dict(changed=False, response=res, component_versions={})
+        module.fail_json(msg="Error querying component versions", **result)
+
+    result = dict(changed=False, component_versions=response.json())
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/component_versions.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/component_versions.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -4,3 +4,4 @@ plugins/modules/events.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/support_levels.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/infra_envs.py validate-modules:missing-gplv3-license # ignore gplv3
 plugins/modules/openshift_versions.py validate-modules:missing-gplv3-license # ignore gplv3
+plugins/modules/component_versions.py validate-modules:missing-gplv3-license # ignore gplv3

--- a/tests/unit/test_component_versions.py
+++ b/tests/unit/test_component_versions.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+# assisted-by: Claude 3.5 Sonnet (Cursor)
+
+"""
+Unit tests for component_versions module
+"""
+
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+
+# Add the plugins directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'plugins', 'modules'))
+
+try:
+    import component_versions
+except ImportError:
+    # Handle case where module dependencies aren't available
+    component_versions = None
+
+
+class TestComponentVersions(unittest.TestCase):
+    """Test cases for component_versions module"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        if component_versions is None:
+            self.skipTest("component_versions module not available")
+        
+        self.mock_module_args = {
+            'openshift_version': None,
+            'cpu_architecture': None,
+        }
+
+    @patch('component_versions.apitoken.GetToken')
+    @patch('component_versions.apiurl.GetURL')
+    @patch('component_versions.requests.get')
+    @patch('component_versions.AnsibleModule')
+    def test_run_module_success(self, mock_ansible_module, mock_requests_get, mock_get_url, mock_get_token):
+        """Test successful API call"""
+        # Mock the token and URL
+        mock_get_token.return_value = "fake-token"
+        mock_get_url.return_value = "https://api.openshift.com/api/assisted-install/v2/component-versions"
+        
+        # Mock successful API response
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {
+            "4.18.1": {
+                "components": {
+                    "cluster-version-operator": "4.18.1",
+                    "machine-config-operator": "4.18.1"
+                },
+                "openshift_version": "4.18.1",
+                "cpu_architecture": "x86_64"
+            }
+        }
+        mock_requests_get.return_value = mock_response
+        
+        # Mock AnsibleModule
+        mock_module_instance = MagicMock()
+        mock_module_instance.params = self.mock_module_args
+        mock_ansible_module.return_value = mock_module_instance
+        
+        # Run the module
+        component_versions.run_module()
+        
+        # Verify API call was made with correct parameters
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        self.assertIn('headers', call_args.kwargs)
+        self.assertEqual(call_args.kwargs['headers']['Authorization'], 'Bearer fake-token')
+        
+        # Verify exit_json was called with success
+        mock_module_instance.exit_json.assert_called_once()
+        exit_args = mock_module_instance.exit_json.call_args[1]
+        self.assertFalse(exit_args['changed'])
+        self.assertIn('component_versions', exit_args)
+
+    @patch('component_versions.apitoken.GetToken')
+    @patch('component_versions.apiurl.GetURL')
+    @patch('component_versions.requests.get')
+    @patch('component_versions.AnsibleModule')
+    def test_run_module_with_filters(self, mock_ansible_module, mock_requests_get, mock_get_url, mock_get_token):
+        """Test API call with filters"""
+        # Mock the token and URL
+        mock_get_token.return_value = "fake-token"
+        mock_get_url.return_value = "https://api.openshift.com/api/assisted-install/v2/component-versions"
+        
+        # Mock successful API response
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {}
+        mock_requests_get.return_value = mock_response
+        
+        # Mock AnsibleModule with parameters
+        mock_module_instance = MagicMock()
+        mock_module_instance.params = {
+            'openshift_version': '4.18',
+            'cpu_architecture': 'x86_64',
+        }
+        mock_ansible_module.return_value = mock_module_instance
+        
+        # Run the module
+        component_versions.run_module()
+        
+        # Verify API call was made with query parameters
+        mock_requests_get.assert_called_once()
+        call_args = mock_requests_get.call_args
+        self.assertIn('params', call_args.kwargs)
+        self.assertEqual(call_args.kwargs['params']['openshift_version'], '4.18')
+        self.assertEqual(call_args.kwargs['params']['cpu_architecture'], 'x86_64')
+
+    @patch('component_versions.apitoken.GetToken')
+    @patch('component_versions.apiurl.GetURL')
+    @patch('component_versions.requests.get')
+    @patch('component_versions.AnsibleModule')
+    def test_run_module_api_failure(self, mock_ansible_module, mock_requests_get, mock_get_url, mock_get_token):
+        """Test API failure handling"""
+        # Mock the token and URL
+        mock_get_token.return_value = "fake-token"
+        mock_get_url.return_value = "https://api.openshift.com/api/assisted-install/v2/component-versions"
+        
+        # Mock failed API response
+        mock_response = MagicMock()
+        mock_response.ok = False
+        mock_response.json.return_value = {"error": "Not found"}
+        mock_requests_get.return_value = mock_response
+        
+        # Mock AnsibleModule
+        mock_module_instance = MagicMock()
+        mock_module_instance.params = self.mock_module_args
+        mock_ansible_module.return_value = mock_module_instance
+        
+        # Run the module
+        component_versions.run_module()
+        
+        # Verify fail_json was called
+        mock_module_instance.fail_json.assert_called_once()
+        fail_args = mock_module_instance.fail_json.call_args[1]
+        self.assertEqual(fail_args['msg'], "Error querying component versions")
+        self.assertFalse(fail_args['changed'])
+        self.assertEqual(fail_args['component_versions'], {})
+
+    @patch('component_versions.HAS_REQUESTS', False)
+    @patch('component_versions.AnsibleModule')
+    def test_run_module_missing_requests(self, mock_ansible_module):
+        """Test handling of missing requests library"""
+        # Mock AnsibleModule
+        mock_module_instance = MagicMock()
+        mock_module_instance.params = self.mock_module_args
+        mock_ansible_module.return_value = mock_module_instance
+        
+        # Run the module
+        component_versions.run_module()
+        
+        # Verify fail_json was called due to missing requests
+        mock_module_instance.fail_json.assert_called_once()
+        fail_args = mock_module_instance.fail_json.call_args[1]
+        self.assertIn("requests", fail_args['msg'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
assisted-by: Claude 3.5 Sonnet (Cursor)

gist of Cursor (for context): https://gist.github.com/dkosteck/bc001d516020c07f097c303ebd759767

## Summary by Sourcery

Introduce the component_versions module for the Assisted Installer collection, including implementation, documentation updates, example usage, and unit tests

New Features:
- Add component_versions Ansible module to query supported OpenShift component versions with optional version and architecture filters

Documentation:
- Document the component_versions module and list all available modules in README
- Provide an example playbook for using component_versions

Tests:
- Add unit tests for component_versions module covering successful calls, filtered queries, API failures, and missing dependencies